### PR TITLE
RSS: escape_html on plugin description

### DIFF
--- a/app/views/jenkins_plugins/show_rss.haml
+++ b/app/views/jenkins_plugins/show_rss.haml
@@ -9,7 +9,7 @@
   - @plugins['plugins'].to_a.sort { |a, b| Time.parse(b[1]['releaseTimestamp']) - Time.parse(a[1]['releaseTimestamp']) }.each do |key, plugin|
    %item
     %title= plugin['title'] + ' ' + plugin['version']
-    %description= plugin['excerpt']
+    %description= escape_html plugin['excerpt']
     %link= plugin['wiki']
     %author= plugin['developers'].map { |developer| developer['name'] }.join(', ')
     %pubDate= Time.parse(plugin['releaseTimestamp']).rfc2822


### PR DESCRIPTION
Hi,

I've tried to subscribe to some http://jenkins-plugin-hub.heroku.com RSS feed in Thunderbird, but it fails because of HTML markups and entities not being escaped in the items description. This simple patch seems to be enough to fix it.

Thanks,
Thomas.
